### PR TITLE
Add personal GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # jinwoo-Sync.github.io
+
+This repository contains my personal homepage that is served via **GitHub Pages**.
+
+Navigate through the site to see the languages I use, my CV, research papers and reviews, as well as my GitHub contribution graph.

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jinwoo's Homepage</title>
+    <title>Contact</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -17,10 +17,8 @@
     </ul>
 </nav>
 <div class="container">
-    <h1>Welcome to My Homepage</h1>
-    <p>This site is hosted with GitHub Pages.</p>
-    <h2>GitHub Contributions</h2>
-    <img src="https://ghchart.rshah.org/jinwoo-Sync" alt="jinwoo-Sync's GitHub chart" />
+    <h1>Contact</h1>
+    <p>You can add your contact information and photo here.</p>
 </div>
 </body>
 </html>

--- a/cv.html
+++ b/cv.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jinwoo's Homepage</title>
+    <title>CV</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -17,10 +17,8 @@
     </ul>
 </nav>
 <div class="container">
-    <h1>Welcome to My Homepage</h1>
-    <p>This site is hosted with GitHub Pages.</p>
-    <h2>GitHub Contributions</h2>
-    <img src="https://ghchart.rshah.org/jinwoo-Sync" alt="jinwoo-Sync's GitHub chart" />
+    <h1>Curriculum Vitae</h1>
+    <p>Here is my CV. You can replace this text with a link to your PDF.</p>
 </div>
 </body>
 </html>

--- a/languages.html
+++ b/languages.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jinwoo's Homepage</title>
+    <title>Languages</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -17,10 +17,15 @@
     </ul>
 </nav>
 <div class="container">
-    <h1>Welcome to My Homepage</h1>
-    <p>This site is hosted with GitHub Pages.</p>
-    <h2>GitHub Contributions</h2>
-    <img src="https://ghchart.rshah.org/jinwoo-Sync" alt="jinwoo-Sync's GitHub chart" />
+    <h1>Languages &amp; Tools</h1>
+    <ul>
+        <li>C++</li>
+        <li>C#</li>
+        <li>Kotlin</li>
+        <li>MySQL</li>
+        <li>PostgreSQL</li>
+        <li>gdrant</li>
+    </ul>
 </div>
 </body>
 </html>

--- a/papers.html
+++ b/papers.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Jinwoo's Homepage</title>
+    <title>Papers</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -17,10 +17,8 @@
     </ul>
 </nav>
 <div class="container">
-    <h1>Welcome to My Homepage</h1>
-    <p>This site is hosted with GitHub Pages.</p>
-    <h2>GitHub Contributions</h2>
-    <img src="https://ghchart.rshah.org/jinwoo-Sync" alt="jinwoo-Sync's GitHub chart" />
+    <h1>Research Papers</h1>
+    <p>This section will include my current papers and reviews.</p>
 </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,29 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+nav {
+    background-color: #333;
+    color: white;
+    padding: 0.5em 1em;
+}
+nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+}
+nav li {
+    margin-right: 1em;
+}
+nav a {
+    color: white;
+    text-decoration: none;
+}
+nav a:hover {
+    text-decoration: underline;
+}
+.container {
+    padding: 1em;
+}


### PR DESCRIPTION
## Summary
- create basic multi-page website
- list programming languages
- show placeholder CV, papers, and contact info
- embed GitHub contribution chart
- document the site in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845b1c09ff08325ae0ce8f365385f70