### PR TITLE
Revamp CV and update homepage intro

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -3,11 +3,51 @@ layout: default
 title: CV
 ---
 <div class="container py-5" data-aos="fade-up">
-    <h1 class="mb-4">Curriculum Vitae</h1>
+  <h1 class="mb-4">Curriculum Vitae</h1>
+
+  <section class="mb-5">
+    <h2 class="h4">About Me</h2>
+    <p>
+      기계공학적 배경에 코딩 역량을 접목하여 새로운 가능성을 끊임없이 탐구하며 성장하고 있는 개발자입니다. 특히
+      카메라-LiDAR 캘리브레이션을 시작으로 SLAM의 기초를 다졌으며, 캘리브레이션 및 LIDAR SLAM 백엔드 최적화를 위해 선형대수와 최적화 이론을 계속해서 공부하고 있습니다.
+      현재는 안드로이드 기반 실시간 위치 보정 및 스트리밍 서버 프로젝트를 주도하고 있습니다. 안드로이드 폰의 카메라, IMU, GPS 센서 데이터를 서버로 전송하여 Visual SLAM과 기존 LiDAR
+      SLAM 맵 매칭 및 DB 매칭을 통해 실시간 GPS 위치 보정을 구현 중입니다. 더불어, 실시간 스트리밍 서버를 구축하여 다수의 클라이언트 앱과 서버 간의 원활한 통신 환경 구축을 개발하고 있습니다.
+      이러한 경험을 바탕으로, 저는 복잡한 시스템을 이해하고 최적화하며, 실제 문제 해결에 기여하는 데 강점을 가지고 있습니다.
+    </p>
+  </section>
+
+  <section class="mb-5">
+    <h2 class="h4">Projects</h2>
     <ul class="list-unstyled">
-        <li>컴퓨터 비젼</li>
-        <li>Lidar SLAM</li>
-        <li>MMS System</li>
-        <li>대규모 지도 데이터 API 서비스</li>
+      <li>컴퓨터 비전 응용</li>
+      <li>Lidar SLAM 백엔드</li>
+      <li>MMS System</li>
+      <li>대규모 지도 데이터 API 서비스</li>
     </ul>
+  </section>
+
+  <section class="mb-5">
+    <h2 class="h4">Photo &amp; Skills</h2>
+    <div class="row align-items-center">
+      <div class="col-md-3 mb-3 text-center">
+        <img src="https://via.placeholder.com/150" alt="profile photo" class="img-fluid rounded-circle">
+      </div>
+      <div class="col-md-9">
+        <ul class="list-unstyled">
+          <li>C++, C#, Kotlin</li>
+          <li>Android, Ubuntu, Windows WSL2</li>
+          <li>Socket, PostgreSQL, MySQL, Docker, Kafka</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="h4">Affiliation &amp; Links</h2>
+    <ul class="list-unstyled">
+      <li>소속: <a href="#">회사 이름</a></li>
+      <li>팀: 팀 이름</li>
+      <li><a href="https://github.com/jinwoo-Sync">GitHub</a></li>
+    </ul>
+  </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -6,13 +6,8 @@ title: Home
   <div class="container">
     <h1 class="display-4" data-aos="fade-up">Welcome to My Homepage</h1>
     <p class="lead" data-aos="fade-up" data-aos-delay="200">
-      기계공학적 배경에 코딩 역량을 접목하여 새로운 가능성을 끊임없이 탐구하며 성장하고 있는 개발자입니다. 특히
-      카메라-LiDAR 캘리브레이션을 시작으로 SLAM의 기초를 다졌으며, 캘리브레이션 및 LIDAR SLAM 백엔드 최적화를 위해 선형대수와 최적화 이론을 계속해서 공부하고 있습니다.
-
-      현재는 안드로이드 기반 실시간 위치 보정 및 스트리밍 서버 프로젝트를 주도하고 있습니다. 안드로이드 폰의 카메라, IMU, GPS 센서 데이터를 서버로 전송하여 Visual SLAM과 기존 LiDAR
-      SLAM 맵 매칭 및 DB 매칭을 통해 실시간 GPS 위치 보정을 구현 중입니다. 더불어, 실시간 스트리밍 서버를 구축하여 다수의 클라이언트 앱과 서버 간의 원활한 통신 환경 구축을 개발하고 있습니다.
-
-      이러한 경험을 바탕으로, 저는 복잡한 시스템을 이해하고 최적화하며, 실제 문제 해결에 기여하는 데 강점을 가지고 있습니다.</p>
+      기계공학과 코딩을 융합해 SLAM 및 센서 융합 기술로 실시간 위치 추정 시스템을 개발하며 로보틱스 분야의 한계를 넓히는 개발자입니다.
+    </p>
     <h2 class="h4 mt-4" data-aos="fade-up" data-aos-delay="400">GitHub Contributions</h2>
     <img data-aos="zoom-in" data-aos-delay="600" src="https://ghchart.rshah.org/jinwoo-Sync" alt="jinwoo-Sync's GitHub chart" class="img-fluid">
   </div>


### PR DESCRIPTION
## Summary
- shorten home page introduction
- create detailed CV page with about section, projects, photo/skills, and links

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845d6130ea08325a4151648c22b1182